### PR TITLE
fix the error "Time is out of dual 32-bit range"

### DIFF
--- a/src/lsd_slam_to_pcl.cpp
+++ b/src/lsd_slam_to_pcl.cpp
@@ -6,6 +6,10 @@
 #include <pcl_msgs/PointIndices.h>
 #include <pcl_ros/pcl_nodelet.h>
 
+#include <ros/macros.h>
+
+
+
 LSDSLAMToPCL::LSDSLAMToPCL(ros::NodeHandle& nh, std::string& name) :
     nh_(nh),
     node_name_(name),
@@ -13,9 +17,15 @@ LSDSLAMToPCL::LSDSLAMToPCL(ros::NodeHandle& nh, std::string& name) :
     min_near_support_(5),
     scaled_depth_var_thresh_(1),
     abs_depth_var_thresh_(1)
-{}
+{
 
-LSDSLAMToPCL::~LSDSLAMToPCL() {}
+
+}
+
+LSDSLAMToPCL::~LSDSLAMToPCL() {
+
+
+}
 
 bool LSDSLAMToPCL::Init()
 {
@@ -143,17 +153,20 @@ void LSDSLAMToPCL::depthCB(const lsd_slam_to_pcl::keyframeMsgConstPtr msg)
             }
         }
 
-        uint64_t time_stamp = ros::Time::now().toNSec();
-
         cloud_pcl.width = width;
         cloud_pcl.height = height;
         cloud_pcl.is_dense = false;
-        indices_ros.header.stamp = pcl_conversions::fromPCL(time_stamp);
+        cloud_pcl.header.frame_id = "frame";
+        pcl_conversions::toPCL(ros::Time::now(), cloud_pcl.header.stamp);
+        indices_ros.header.stamp = ros::Time::now();
+
 
         cloud_publisher_.publish(boost::make_shared<const pcl::PointCloud<pcl::PointXYZRGB> >(cloud_pcl));
         indices_publisher_.publish(boost::make_shared<const pcl_ros::PCLNodelet::PointIndices>(indices_ros));
 
         ROS_DEBUG_STREAM("Published " << num_pts_total << " points to pointcloud, dimensions [" << cloud_pcl.width << " " << cloud_pcl.height << "]");
+
+
 
     }
 


### PR DESCRIPTION
This error occurs in the conversion pcl_conversions::fromPCL(time_stamp)

The fix was:
according the documentation at http://docs.ros.org/groovy/api/pcl_msgs/html/msg/PointIndices.html and 
http://docs.ros.org/groovy/api/std_msgs/html/msg/Header.html the stamp is of type time, then i simply get the time using ros::Time::now()

add for sake of good practice the timestamp to the pcl msg

added as well the frame_id making it possible to see the msg using rviz

Note: I'm new to PCL and computer Vision. I'm working at the moment for my thesis with the LSD-SLAM trying to understand and used the point-cloud generated from the LSD-SLAM algorithm.
I'm using ROS Indigo with Ubuntu 14.04, and without this change I can't run the original code out-of-the-box.

And thanks for sharing your work, it is helping me alot.
